### PR TITLE
fix file same name editing

### DIFF
--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -1,12 +1,15 @@
 export enum NodeType {
-    CONNECTION = 'connection', FOLDER = 'folder', FILE = "file",INFO = "info",Link = "link"
+    CONNECTION = 'connection',
+    FOLDER = 'folder',
+    FILE = "file",
+    INFO = "info",
+    Link = "link"
 }
 
 export enum CacheKey {
     CONECTIONS_CONFIG = "ssh.connections",
     COLLAPSE_SATE = "ssh.cache.collapseState",
 }
-
 
 export enum Command {
     REFRESH = "ssh.refresh"

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -3,7 +3,8 @@ import ServiceManager from "../manager/serviceManager";
 import { join } from "path";
 
 export enum Confirm {
-    YES = "YES", NO = "NO"
+    YES = "YES",
+    NO = "NO"
 }
 
 export class Util {

--- a/src/manager/fileManager.ts
+++ b/src/manager/fileManager.ts
@@ -9,7 +9,9 @@ export class FileManager {
     }
 
     private static check(path: string) {
-        if (!fs.existsSync(path)) fs.mkdirSync(path)
+        if (!fs.existsSync(path)) {
+            fs.mkdirSync(path, { recursive: true })
+        }
     }
 
     public static show(fileName: string) {

--- a/src/node/fileNode.ts
+++ b/src/node/fileNode.ts
@@ -53,12 +53,13 @@ export class FileNode extends AbstractNode {
             return;
         }
         const extName = path.extname(this.file.filename).toLowerCase();
+        
         if (extName == ".gz" || extName == ".exe" || extName == ".7z" || extName == ".jar" || extName == ".bin" || extName == ".tar") {
             vscode.window.showErrorMessage(`Not support open ${extName} file!`)
             return;
         }
         const { sftp } = await ClientManager.getSSH(this.sshConfig)
-        const tempPath = await FileManager.record(`temp/${this.file.filename}`, null, FileModel.WRITE);
+        const tempPath = await FileManager.record(`temp${this.fullPath}`, 'Loading...', FileModel.WRITE);
         sftp.fastGet(this.fullPath, tempPath, async (err) => {
             if (err) {
                 vscode.window.showErrorMessage(err.message)

--- a/src/node/parentNode.ts
+++ b/src/node/parentNode.ts
@@ -68,8 +68,8 @@ export class ParentNode extends AbstractNode {
         vscode.window.showInputBox().then(async input => {
             if (input) {
                 const { sftp } = await ClientManager.getSSH(this.sshConfig)
-                const tempPath = await FileManager.record("temp/" + input, "", FileModel.WRITE);
                 const targetPath = this.fullPath + "/" + input;
+                const tempPath = await FileManager.record(`temp${targetPath}`, "", FileModel.WRITE);
                 sftp.fastPut(tempPath, targetPath, err => {
                     if (err) {
                         vscode.window.showErrorMessage(err.message)


### PR DESCRIPTION
Review `tmp` folder struct to be a tree.  
Files & folders will keep the same tree as in the remote server.  

This allow us to edit multiples files from differents folder with the same name.